### PR TITLE
fix: make navigation item styles consistent

### DIFF
--- a/resources/views/components/nav-item.blade.php
+++ b/resources/views/components/nav-item.blade.php
@@ -9,9 +9,10 @@
         {{ $label }}
     </a>
 @else
-    <div class="inline-flex items-center w-full px-4 py-2 border border-transparent shadow-sm text-sm font-medium rounded-md text-gray-700 dark:text-white bg-gray-200 dark:bg-gray-500 hover:bg-gray-300 dark:hover:bg-gray-600 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500">
+    <label {{ $attributes->merge(['class' => 'inline-flex items-center w-full px-4 py-2 border border-transparent shadow-sm text-sm font-medium rounded-md text-gray-700 dark:text-white bg-gray-200 dark:bg-gray-500 hover:bg-gray-300 dark:hover:bg-gray-600 focus-within:ring-2 focus-within:ring-offset-2 focus-within:ring-indigo-500 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 cursor-pointer']) }} >
         @svg($icon, '-ml-0.5 mr-2 h-4 w-4')
 
-        <input type="{{ $type }}" value="{{ $label }}" {{ $attributes->merge(['class' => 'bg-transparent cursor-pointer font-medium']) }} />
-    </div>
+        <span class="sr-only">{{ $label }}</span>
+        <input type="{{ $type }}" value="{{ $label }}" class="bg-transparent focus:outline-none cursor-pointer" />
+    </label>
 @endisset


### PR DESCRIPTION
Currently we must click on the label on navigation items that are buttons, as opposed to links who behave correctly. This PR fixes just that, by making behavior consistent for both links and buttons.