### PR TITLE
Fix nav border color on dark-mode

### DIFF
--- a/resources/views/components/nav.blade.php
+++ b/resources/views/components/nav.blade.php
@@ -36,7 +36,7 @@
 <div :class="{'hidden': !isOpen }" class="lg:flex lg:flex-shrink-0 print:hidden">
     <div class="flex flex-col w-64">
         <!-- Sidebar component, swap this element with another sidebar if you like -->
-        <div class="flex flex-col h-0 flex-1 border-r border-gray-200 bg-gray-50 dark:border-gray-900 dark:bg-gray-700">
+        <div class="flex flex-col h-0 flex-1 border-r border-gray-200 dark:border-gray-900 bg-gray-50 dark:bg-gray-700">
             <div class="flex-1 flex flex-col pt-8 pb-4 px-6 overflow-y-auto">
                 <x-sidebar>{!! $slot !!}</x-sidebar>
             </div>

--- a/resources/views/components/nav.blade.php
+++ b/resources/views/components/nav.blade.php
@@ -36,7 +36,7 @@
 <div :class="{'hidden': !isOpen }" class="lg:flex lg:flex-shrink-0 print:hidden">
     <div class="flex flex-col w-64">
         <!-- Sidebar component, swap this element with another sidebar if you like -->
-        <div class="flex flex-col h-0 flex-1 border-r border-gray-200 bg-gray-50 dark:bg-gray-700">
+        <div class="flex flex-col h-0 flex-1 border-r border-gray-200 bg-gray-50 dark:border-gray-900 dark:bg-gray-700">
             <div class="flex-1 flex flex-col pt-8 pb-4 px-6 overflow-y-auto">
                 <x-sidebar>{!! $slot !!}</x-sidebar>
             </div>


### PR DESCRIPTION
Noticed the border color on the navigation doesn't change when dark mode is enabled so there's a 1 px off-white right border when dark mode is on, this PR fixes that issue.

The issue might be hard to see in the screenshot, but if you have GitHub's dark mode on you'll see the border. 🙂


### Screenshot of the issue

![Screen Shot 2021-01-18 at 9 25 14 PM](https://user-images.githubusercontent.com/2221746/104960080-d3201a00-59d3-11eb-881e-b7a86b7d1385.png)

### Screenshot of the fix

![Screen Shot 2021-01-18 at 9 25 23 PM](https://user-images.githubusercontent.com/2221746/104960094-d915fb00-59d3-11eb-82fb-bb7e56e69cc4.png)
