### PR TITLE
Fix color-scheme toggle

### DIFF
--- a/resources/views/components/sidebar.blade.php
+++ b/resources/views/components/sidebar.blade.php
@@ -47,7 +47,7 @@
                 <x-heroicon-s-sun class="h-3 w-3 text-gray-400" />
             </span>
 
-            <span class="hidden dark:flex opacity-0 ease-out duration-100 dark:opacity-0 dark:ease-out dark:duration-100 absolute inset-0 h-full w-full items-center justify-center transition-opacity opacity-100 ease-in duration-200 " aria-hidden="true">
+            <span class="hidden dark:flex opacity-0 ease-out duration-100 dark:opacity-100 dark:ease-in dark:duration-200 absolute inset-0 h-full w-full items-center justify-center transition-opacity" aria-hidden="true">
                 <x-heroicon-s-moon class="h-3 w-3 text-gray-600" />
             </span>
         </span>


### PR DESCRIPTION
This PR fixes a UI issue with the color-scheme toggle not showing the moon icon when on dark mode.

<details>
<summary>Before PR fix</summary>

![Screen Shot 2022-08-31 at 6 03 51 PM](https://user-images.githubusercontent.com/2221746/187726144-e46ca415-d421-497d-bb88-262ea6b4e79a.png)

</details>

<details>
<summary>After PR fix</summary>

![Screen Shot 2022-08-31 at 6 04 07 PM](https://user-images.githubusercontent.com/2221746/187726043-c8ae605f-1700-4904-a80c-41043421f3d4.png)

</details>