### PR TITLE
#122 Update to Heroicons v2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
     "license": "MIT",
     "require": {
         "php": "8.1.*",
-        "blade-ui-kit/blade-heroicons": "^1.3",
+        "blade-ui-kit/blade-heroicons": "^2.0",
         "guzzlehttp/guzzle": "^7.2",
         "laravel/framework": "^9.19",
         "laravel/tinker": "^2.7",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a770039ada6feb2bde2705b7b0c61db8",
+    "content-hash": "55d921bfa46a2e0bfe89ee22c9e9ef48",
     "packages": [
         {
             "name": "aws/aws-crt-php",
@@ -149,25 +149,25 @@
         },
         {
             "name": "blade-ui-kit/blade-heroicons",
-            "version": "1.3.1",
+            "version": "2.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/blade-ui-kit/blade-heroicons.git",
-                "reference": "a2749abc7b8eb6149ff643ffa99a3d33a2de7961"
+                "reference": "ecd25c602c94600e0c057ba1034a1f2ba770503a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/blade-ui-kit/blade-heroicons/zipball/a2749abc7b8eb6149ff643ffa99a3d33a2de7961",
-                "reference": "a2749abc7b8eb6149ff643ffa99a3d33a2de7961",
+                "url": "https://api.github.com/repos/blade-ui-kit/blade-heroicons/zipball/ecd25c602c94600e0c057ba1034a1f2ba770503a",
+                "reference": "ecd25c602c94600e0c057ba1034a1f2ba770503a",
                 "shasum": ""
             },
             "require": {
                 "blade-ui-kit/blade-icons": "^1.1",
-                "illuminate/support": "^8.0|^9.0",
-                "php": "^7.4|^8.0"
+                "illuminate/support": "^9.0",
+                "php": "^8.0"
             },
             "require-dev": {
-                "orchestra/testbench": "^6.0|^7.0",
+                "orchestra/testbench": "^7.0",
                 "phpunit/phpunit": "^9.0"
             },
             "type": "library",
@@ -202,7 +202,7 @@
             ],
             "support": {
                 "issues": "https://github.com/blade-ui-kit/blade-heroicons/issues",
-                "source": "https://github.com/blade-ui-kit/blade-heroicons/tree/1.3.1"
+                "source": "https://github.com/blade-ui-kit/blade-heroicons/tree/2.0.2"
             },
             "funding": [
                 {
@@ -214,7 +214,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-03-02T11:50:13+00:00"
+            "time": "2022-08-31T08:47:40+00:00"
         },
         {
             "name": "blade-ui-kit/blade-icons",

--- a/resources/views/components/main.blade.php
+++ b/resources/views/components/main.blade.php
@@ -15,7 +15,7 @@
                 >
                     <span class="sr-only">Open sidebar</span>
 
-                    <x-heroicon-o-menu class="h-6 w-6" />
+                    <x-heroicon-o-bars-3 class="h-6 w-6" />
                 </button>
             </div>
         </div>

--- a/resources/views/components/nav.blade.php
+++ b/resources/views/components/nav.blade.php
@@ -22,7 +22,7 @@
                 >
                     <span class="sr-only">Close sidebar</span>
 
-                    <x-heroicon-o-x class="h-6 w-6 text-white" />
+                    <x-heroicon-o-x-mark class="h-6 w-6 text-white" />
                 </button>
             </div>
             <div class="flex-1 flex flex-col pt-8 pb-4 px-6 overflow-y-auto">

--- a/resources/views/create.blade.php
+++ b/resources/views/create.blade.php
@@ -10,7 +10,7 @@
             </x-main>
 
             <x-nav>
-                <x-nav-item label="Save" type="submit" icon="heroicon-o-arrow-down-on-square" />
+                <x-nav-item label="Save" type="submit" icon="heroicon-o-folder-plus" />
                 <x-nav-item label="Reset" type="reset" icon="heroicon-o-no-symbol" />
             </x-nav>
         </div>

--- a/resources/views/create.blade.php
+++ b/resources/views/create.blade.php
@@ -10,8 +10,8 @@
             </x-main>
 
             <x-nav>
-                <x-nav-item label="Save" type="submit" icon="heroicon-o-save" />
-                <x-nav-item label="Reset" type="reset" icon="heroicon-o-ban" />
+                <x-nav-item label="Save" type="submit" icon="heroicon-o-arrow-down-on-square" />
+                <x-nav-item label="Reset" type="reset" icon="heroicon-o-no-symbol" />
             </x-nav>
         </div>
     </form>

--- a/resources/views/edit.blade.php
+++ b/resources/views/edit.blade.php
@@ -10,7 +10,7 @@
             </x-main>
 
             <x-nav>
-                <x-nav-item label="Save" type="submit" icon="heroicon-o-arrow-down-on-square" />
+                <x-nav-item label="Save" type="submit" icon="heroicon-o-folder-plus" />
                 <x-nav-item label="Reset" type="reset" icon="heroicon-o-no-symbol" />
                 <x-nav-item label="Back" :link="route('show', $paste->hash)" icon="heroicon-o-arrow-left-circle" />
             </x-nav>

--- a/resources/views/edit.blade.php
+++ b/resources/views/edit.blade.php
@@ -10,9 +10,9 @@
             </x-main>
 
             <x-nav>
-                <x-nav-item label="Save" type="submit" icon="heroicon-o-save" />
-                <x-nav-item label="Reset" type="reset" icon="heroicon-o-ban" />
-                <x-nav-item label="Back" :link="route('show', $paste->hash)" icon="heroicon-o-arrow-circle-left" />
+                <x-nav-item label="Save" type="submit" icon="heroicon-o-arrow-down-on-square" />
+                <x-nav-item label="Reset" type="reset" icon="heroicon-o-no-symbol" />
+                <x-nav-item label="Back" :link="route('show', $paste->hash)" icon="heroicon-o-arrow-left-circle" />
             </x-nav>
         </div>
     </form>

--- a/resources/views/show.blade.php
+++ b/resources/views/show.blade.php
@@ -10,7 +10,7 @@
         </x-main>
 
         <x-nav>
-            <x-nav-item label="New" :link="route('home')" icon="heroicon-o-document-add" />
+            <x-nav-item label="New" :link="route('home')" icon="heroicon-o-document-plus" />
             <x-nav-item
                 label="Copy"
                 type="button"
@@ -19,7 +19,7 @@
                 data-clipboard-text="{{ $paste->code }}"
             />
             <x-nav-item label="Fork" :link="route('edit', $paste->hash)" icon="heroicon-o-document-duplicate" />
-            <x-nav-item label="Raw" :link="route('raw', $paste->hash)" icon="heroicon-o-external-link" blank />
+            <x-nav-item label="Raw" :link="route('raw', $paste->hash)" icon="heroicon-o-arrow-top-right-on-square" blank />
         </x-nav>
     </div>
 @stop


### PR DESCRIPTION
This PR bumps `blade-ui-kit/blade-heroicons` dependency to v2.0, and updates the necessary icons to their [Heroicons](https://heroicons.com/) v2.0 equivalents. Will update PR if the icons need to change as per the question posed in the issue.

Closes #122 